### PR TITLE
Fixes to Video Reports

### DIFF
--- a/app/Http/Controllers/VideoReportController.php
+++ b/app/Http/Controllers/VideoReportController.php
@@ -47,51 +47,101 @@ class VideoReportController extends Controller
 
     public function show(Request $request, string $id)
     {
-        $report = Video::findOrFail($id);
+        $video = Video::findOrFail($id);
 
-        if ($report->user_id !== Auth::id()) {
+        if ($video->user_id !== Auth::id()) {
             abort(403, 'Unauthorized action.');
         }
 
+        // Add queue position for queued videos
+        $queuePosition = null;
+        $estimatedWaitTime = null;
+        if ($video->video_status === 'queued') {
+            $queuePosition = Video::where('video_status', 'queued')
+                ->where('created_at', '<', $video->created_at)
+                ->count() + 1;
+            $estimatedWaitTime = $this->calculateEstimatedWaitTime($queuePosition);
+        }
+
         return Inertia::render('Reports/VideoReportDetail', [
-            'report' => $report,
-            'frames' => $this->getFramePairs($report)
+            'report' => array_merge($video->toArray(), [
+                'queue_position' => $queuePosition,
+                'estimated_wait_time' => $estimatedWaitTime,
+            ]),
+            'frames' => $video->video_status === 'completed' ? $this->getFramePairs($video) : []
         ]);
     }
 
-    private function getFramePairs(Video $report)
+    private function getFramePairs(Video $video)
     {
-        $pattern = $report->video_path . '_*.jpg';
-        $original_frames = Storage::disk('frames')->files('', false);
-        $visualized_frames = Storage::disk('gradcam_frames')->files('', false);
+        // Only attempt to get frames if video processing is completed
+        if ($video->video_status !== 'completed') {
+            return [];
+        }
 
-        // Filter frames matching the pattern
-        $original_frames = array_filter($original_frames, function($frame) use ($pattern) {
-            return fnmatch($pattern, basename($frame));
-        });
+        try {
+            $pattern = $video->video_path . '_*.jpg';
+            $original_frames = Storage::disk('frames')->files('', false);
+            $visualized_frames = Storage::disk('gradcam_frames')->files('', false);
 
-        $visualized_frames = array_filter($visualized_frames, function($frame) use ($pattern) {
-            return fnmatch($pattern, basename($frame));
-        });
+            // Filter frames matching the pattern
+            $original_frames = array_filter($original_frames, function($frame) use ($pattern) {
+                return fnmatch($pattern, basename($frame));
+            });
 
-        // Sort frames to ensure they're in order
-        sort($original_frames);
-        sort($visualized_frames);
+            $visualized_frames = array_filter($visualized_frames, function($frame) use ($pattern) {
+                return fnmatch($pattern, basename($frame));
+            });
 
-        // Create frame pairs for the view
-        return array_map(function ($original, $visualized) use ($report) {
-            return [
-                'original' => route('frame.show', [
-                    'video' => $report->id,
-                    'type' => 'original',
-                    'filename' => basename($original)
-                ]),
-                'visualized' => route('frame.show', [
-                    'video' => $report->id,
-                    'type' => 'visualized',
-                    'filename' => basename($visualized)
-                ])
-            ];
-        }, $original_frames, $visualized_frames);
+            // If no frames found, return empty array
+            if (empty($original_frames) || empty($visualized_frames)) {
+                return [];
+            }
+
+            // Sort frames to ensure they're in order
+            sort($original_frames);
+            sort($visualized_frames);
+
+            // Create frame pairs for the view
+            return array_map(function ($original, $visualized) use ($video) {
+                return [
+                    'original' => route('frame.show', [
+                        'video' => $video->id,
+                        'type' => 'original',
+                        'filename' => basename($original)
+                    ]),
+                    'visualized' => route('frame.show', [
+                        'video' => $video->id,
+                        'type' => 'visualized',
+                        'filename' => basename($visualized)
+                    ])
+                ];
+            }, $original_frames, $visualized_frames);
+
+        } catch (\Exception $e) {
+            // Log the error but don't expose it to the user
+            \Log::error('Error getting frame pairs: ' . $e->getMessage());
+            return [];
+        }
+    }
+
+    private function calculateEstimatedWaitTime($queuePosition)
+    {
+        // Assuming each video takes approximately 2 minutes to process
+        $minutesPerVideo = 2;
+        $totalMinutes = $queuePosition * $minutesPerVideo;
+
+        if ($totalMinutes < 60) {
+            return $totalMinutes . ' minutes';
+        }
+
+        $hours = floor($totalMinutes / 60);
+        $minutes = $totalMinutes % 60;
+
+        if ($hours === 1) {
+            return "1 hour " . ($minutes > 0 ? "and $minutes minutes" : '');
+        }
+
+        return "$hours hours " . ($minutes > 0 ? "and $minutes minutes" : '');
     }
 }

--- a/resources/js/Pages/Reports/VideoReportDetail.vue
+++ b/resources/js/Pages/Reports/VideoReportDetail.vue
@@ -123,11 +123,20 @@ const statusInfo = getStatusInfo(props.report.video_status);
                         
                         <!-- Additional guidance based on status -->
                         <div class="text-sm text-gray-500 dark:text-gray-400 text-center max-w-md">
-                            <p v-if="report.video_status === 'queued'">
-                                Your video is #{{ report.queue_position }} in the queue. 
-                                Estimated processing time: {{ report.estimated_wait_time || '5-10 minutes' }}
+                            <p v-if="report.video_status === 'queued' && report.queue_info">
+                                <span v-if="report.queue_info.position === 1">
+                                    Your video is next in line for processing.
+                                </span>
+                                <span v-else>
+                                    There {{ report.queue_info.position - 1 === 1 ? 'is' : 'are' }} 
+                                    {{ report.queue_info.position - 1 }} 
+                                    {{ report.queue_info.position - 1 === 1 ? 'video' : 'videos' }} ahead of yours.
+                                </span>
+                                <br>
+                                <span class="mt-2 block">
+                                    Estimated wait time: {{ report.queue_info.estimated_time }}
+                                </span>
                             </p>
-                            <!-- Processing state now only shows the spinning icon from statusInfo -->
                         </div>
 
                         <!-- Refresh button -->

--- a/resources/js/Pages/Reports/VideoReportDetail.vue
+++ b/resources/js/Pages/Reports/VideoReportDetail.vue
@@ -15,6 +15,44 @@ const props = defineProps({
     }
 });
 
+// Helper function to get status message and icon
+function getStatusInfo(status) {
+    const statusMap = {
+        'queued': {
+            message: 'Your video is currently in the processing queue. Please check back later.',
+            icon: `<svg class="w-8 h-8 text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>`,
+            color: 'text-yellow-600 dark:text-yellow-400'
+        },
+        'processing': {
+            message: 'Your video is currently being analyzed. This may take a few minutes.',
+            icon: `<svg class="w-8 h-8 text-blue-500 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>`,
+            color: 'text-blue-600 dark:text-blue-400'
+        },
+        'error': {
+            message: 'An error occurred while processing your video. Please try uploading it again.',
+            icon: `<svg class="w-8 h-8 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>`,
+            color: 'text-red-600 dark:text-red-400'
+        },
+        'completed': {
+            message: 'Analysis completed successfully.',
+            icon: `<svg class="w-8 h-8 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>`,
+            color: 'text-green-600 dark:text-green-400'
+        }
+    };
+
+    return statusMap[status] || statusMap['error'];
+}
+
+const statusInfo = getStatusInfo(props.report.video_status);
 </script>
 
 <template>
@@ -74,7 +112,38 @@ const props = defineProps({
                 <!-- Frame Comparison Gallery -->
                 <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
                     <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-4">Frame Analysis</h3>
-                    <div class="space-y-6">
+                    
+                    <!-- Status Message for non-completed states -->
+                    <div v-if="report.video_status !== 'completed'" 
+                         class="flex flex-col items-center justify-center p-8 space-y-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
+                        <div v-html="statusInfo.icon"></div>
+                        <p class="text-lg font-medium" :class="statusInfo.color">
+                            {{ statusInfo.message }}
+                        </p>
+                        
+                        <!-- Additional guidance based on status -->
+                        <div class="text-sm text-gray-500 dark:text-gray-400 text-center max-w-md">
+                            <p v-if="report.video_status === 'queued'">
+                                Your video is #{{ report.queue_position }} in the queue. 
+                                Estimated processing time: {{ report.estimated_wait_time || '5-10 minutes' }}
+                            </p>
+                            <!-- Processing state now only shows the spinning icon from statusInfo -->
+                        </div>
+
+                        <!-- Refresh button -->
+                        <button
+                            @click="$inertia.reload({ preserveScroll: true })"
+                            class="mt-4 inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800"
+                        >
+                            <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                            </svg>
+                            Refresh Status
+                        </button>
+                    </div>
+
+                    <!-- Frame comparison gallery for completed videos -->
+                    <div v-else-if="frames.length > 0" class="space-y-6">
                         <template v-for="(frame, index) in frames" :key="index">
                             <div class="flex flex-col md:flex-row gap-4">
                                 <!-- Original Frame -->
@@ -96,6 +165,11 @@ const props = defineProps({
                                 </div>
                             </div>
                         </template>
+                    </div>
+
+                    <!-- No frames available message -->
+                    <div v-else class="text-center py-8 text-gray-500 dark:text-gray-400">
+                        <p>No frames are available for this video.</p>
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/Reports/VideoReportsOverview.vue
+++ b/resources/js/Pages/Reports/VideoReportsOverview.vue
@@ -3,7 +3,7 @@ import {Head, Link} from "@inertiajs/vue3";
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
 import TableRow from "@/Components/TableRow.vue";
 import Pagination from '@/Components/Pagination.vue';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { router } from '@inertiajs/vue3';
 
 const props = defineProps({
@@ -36,6 +36,18 @@ const clearFilters = () => {
     router.get(route('reports.index'));
 };
 
+const isRefreshing = ref(false);
+
+function refreshReports() {
+    isRefreshing.value = true;
+    router.reload({ 
+        preserveScroll: true,
+        onFinish: () => {
+            isRefreshing.value = false;
+        }
+    });
+}
+
 </script>
 
 <template>
@@ -43,7 +55,30 @@ const clearFilters = () => {
 
     <AuthenticatedLayout>
         <template #header>
-            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">Reports</h2>
+            <div class="flex justify-between items-center">
+                <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                    Video Reports
+                </h2>
+                <div class="flex items-center space-x-4">
+                    <!-- Refresh Button -->
+                    <button
+                        @click="refreshReports"
+                        :disabled="isRefreshing"
+                        class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800 disabled:opacity-50 transition-opacity duration-150"
+                    >
+                        <svg 
+                            class="w-4 h-4 mr-2"
+                            :class="{ 'animate-spin': isRefreshing }"
+                            fill="none" 
+                            viewBox="0 0 24 24" 
+                            stroke="currentColor"
+                        >
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                        </svg>
+                        {{ isRefreshing ? 'Refreshing...' : 'Refresh Status' }}
+                    </button>
+                </div>
+            </div>
         </template>
 
         <div class="py-12">

--- a/resources/js/Pages/Reports/VideoReportsOverview.vue
+++ b/resources/js/Pages/Reports/VideoReportsOverview.vue
@@ -3,8 +3,10 @@ import {Head, Link} from "@inertiajs/vue3";
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
 import TableRow from "@/Components/TableRow.vue";
 import Pagination from '@/Components/Pagination.vue';
+import { computed } from 'vue';
+import { router } from '@inertiajs/vue3';
 
-defineProps({
+const props = defineProps({
     videos: {
         type: Object,
         required: true
@@ -14,6 +16,25 @@ defineProps({
         required: true
     }
 });
+
+// Check if any filters are active
+const hasActiveFilters = computed(() => {
+    return Object.values(props.filters).some(value => value !== null && value !== '');
+});
+
+// Check if there are any videos in the database
+const hasNoVideos = computed(() => {
+    return props.videos.total === 0 && !hasActiveFilters.value;
+});
+
+// Check if filters returned no results
+const hasNoFilterResults = computed(() => {
+    return props.videos.total === 0 && hasActiveFilters.value;
+});
+
+const clearFilters = () => {
+    router.get(route('reports.index'));
+};
 
 </script>
 
@@ -27,8 +48,8 @@ defineProps({
 
         <div class="py-12">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                <!-- No Videos State -->
-                <div v-if="!videos.data.length" class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-8 text-center">
+                <!-- No Videos Uploaded State -->
+                <div v-if="hasNoVideos" class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-8 text-center">
                     <div class="flex flex-col items-center justify-center space-y-4">
                         <svg class="w-16 h-16 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
@@ -49,18 +70,37 @@ defineProps({
                     </div>
                 </div>
 
-                <TableRow 
-                    :videos="videos.data" 
-                    :filters="filters"
-                    :current-page="videos.current_page"
-                    :per-page="videos.per_page"
-                />
-
-                <!-- Pagination -->
-                <div class="mt-6">
-                    <Pagination :links="videos.links" />
+                <!-- No Results After Filtering -->
+                <div v-else-if="hasNoFilterResults" class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-8 text-center">
+                    <div class="flex flex-col items-center justify-center space-y-4">
+                        <svg class="w-16 h-16 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+                        </svg>
+                        <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">No Matching Results</h3>
+                        <p class="text-gray-500 dark:text-gray-400">
+                            Try adjusting your filters to find what you're looking for.
+                        </p>
+                        <button
+                            @click="clearFilters"
+                            class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800"
+                        >
+                            Clear Filters
+                        </button>
+                    </div>
                 </div>
 
+                <!-- Results Table -->
+                <template v-else>
+                    <TableRow 
+                        :videos="videos.data" 
+                        :filters="filters"
+                        :current-page="videos.current_page"
+                        :per-page="videos.per_page"
+                    />
+                    <div class="mt-6">
+                        <Pagination :links="videos.links" />
+                    </div>
+                </template>
             </div>
         </div>
     </AuthenticatedLayout>

--- a/resources/js/Pages/Reports/VideoReportsOverview.vue
+++ b/resources/js/Pages/Reports/VideoReportsOverview.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {Head} from "@inertiajs/vue3";
+import {Head, Link} from "@inertiajs/vue3";
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
 import TableRow from "@/Components/TableRow.vue";
 import Pagination from '@/Components/Pagination.vue';
@@ -27,6 +27,27 @@ defineProps({
 
         <div class="py-12">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <!-- No Videos State -->
+                <div v-if="!videos.data.length" class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-8 text-center">
+                    <div class="flex flex-col items-center justify-center space-y-4">
+                        <svg class="w-16 h-16 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                        </svg>
+                        <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">No Videos Found</h3>
+                        <p class="text-gray-500 dark:text-gray-400 max-w-sm">
+                            Start by uploading a video from your dashboard to analyze it for deepfake content.
+                        </p>
+                        <Link
+                            :href="route('dashboard')"
+                            class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800"
+                        >
+                            <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                            </svg>
+                            Upload Video
+                        </Link>
+                    </div>
+                </div>
 
                 <TableRow 
                     :videos="videos.data" 


### PR DESCRIPTION
This PR fixes bugs in the video reports interface such as:

- Add status handling for Video Processing
  - If user wants the details of video that is in queue or is being processed, then the frame comparisons is replaced by helpful guided messages
  - Add estimated time for the queued video
- Add notifications for the Filter states
  - If user starts fresh and navigated to the report overview page, he's greeted with message too upload videos to the dashboard
  - If user specified filtering criteria doesn't returns anything, then he's told so
- Add refresh functionality for video reports overview